### PR TITLE
Show final success message after all HEVC conversions

### DIFF
--- a/ffmpeg_stream_selector.py
+++ b/ffmpeg_stream_selector.py
@@ -152,6 +152,8 @@ class StreamSelectorApp:
             messagebox.showwarning("No File", "Please select a folder first.")
             return
 
+        converted_files = []
+
         for input_file in self.video_files:
             try:
                 result = subprocess.run(
@@ -209,12 +211,17 @@ class StreamSelectorApp:
                 subprocess.run(cmd, check=True)
                 self.processed_dirs.add(converted_dir)
                 self.current_file = output_path
-                messagebox.showinfo("Success", "Video converted:\n" + output_path)
+                converted_files.append(output_path)
             except subprocess.CalledProcessError as e:
                 print("FFmpeg error:", e)
                 messagebox.showerror(
                     "Error", f"FFmpeg failed during conversion of {input_file}."
                 )
+
+        if converted_files:
+            messagebox.showinfo(
+                "Success", "Videos converted:\n" + "\n".join(converted_files)
+            )
 
     def update_streams(self):
         if not getattr(self, "video_files", None):


### PR DESCRIPTION
## Summary
- only show a single summary dialog after converting all files to HEVC

## Testing
- `python -m py_compile ffmpeg_stream_selector.py`
- `flake8 ffmpeg_stream_selector.py` *(fails: F401/E501 and other pre-existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687619c5ea348320b903f3e0ec29cfb6