### PR TITLE
Remove duplicate stream names

### DIFF
--- a/ffmpeg_stream_selector.py
+++ b/ffmpeg_stream_selector.py
@@ -178,7 +178,7 @@ class StreamSelectorApp:
             if "forced" in title.lower():
                 label += " [FORCED]"
             if title:
-                label += f" ({title})" * 3
+                label += f" ({title})"
             audio_options.append(label)
 
             if default_audio is None and lang.lower() == "eng":
@@ -192,7 +192,7 @@ class StreamSelectorApp:
             if "forced" in title.lower():
                 label += " [FORCED]"
             if title:
-                label += f" ({title})" * 2
+                label += f" ({title})"
             subtitle_options.append(label)
 
             title_lower = title.lower()


### PR DESCRIPTION
## Summary
- update `populate_stream_dropdowns` to stop repeating stream titles

## Testing
- `python -m py_compile ffmpeg_stream_selector.py`

------
https://chatgpt.com/codex/tasks/task_e_68768b66f9488320a0cdad0922a6f6d3