### PR TITLE
Make default path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ subtitle streams in video files and optionally converting the video stream to
 HEVC using FFmpeg. PyQt allows more customizable widgets, including styled
 buttons.
 
+By default the script opens a directory located at `videos/unprocessed/new`
+within your home folder. You can specify a different location by setting the
+`STREAM_SELECTOR_DIR` environment variable before running the application.
+
 After launching the script, choose a folder containing your videos. Two buttons
 are available and each operation will be applied to every video in the selected
 folder:

--- a/ffmpeg_stream_selector.py
+++ b/ffmpeg_stream_selector.py
@@ -1,6 +1,14 @@
 from pathlib import Path
 import os
 import sys
+
+# Default directory used when no folder is selected. Users can override
+# this path with the STREAM_SELECTOR_DIR environment variable. The default
+# falls back to a "videos/unprocessed/new" directory in the user's home
+# folder to work across operating systems.
+DEFAULT_VIDEO_DIR = Path(
+    os.getenv("STREAM_SELECTOR_DIR", Path.home() / "videos" / "unprocessed" / "new")
+)
 from PyQt5.QtWidgets import (
     QApplication,
     QWidget,
@@ -111,7 +119,7 @@ class StreamSelectorApp(QWidget):
 
     def write_status_log(self):
         """Write collected status information to a JSON file."""
-        output_dir = Path(r"D:\Video\unprocessed\new")
+        output_dir = DEFAULT_VIDEO_DIR
         output_dir.mkdir(parents=True, exist_ok=True)
         with open(output_dir / "conversion_status.json", "w", encoding="utf-8") as f:
             json.dump(self.status_log, f, indent=2)
@@ -146,7 +154,7 @@ class StreamSelectorApp(QWidget):
         folder = QFileDialog.getExistingDirectory(
             self,
             "Select folder with video files",
-            r"D:\\Video\\unprocessed\\new",
+            str(DEFAULT_VIDEO_DIR),
         )
         if not folder:
             return


### PR DESCRIPTION
## Summary
- allow setting default location with `STREAM_SELECTOR_DIR`
- update README with path instructions

## Testing
- `python -m py_compile ffmpeg_stream_selector.py`

------
https://chatgpt.com/codex/tasks/task_e_687a13e7c56c83209b2e83be798c9733