### PR TITLE
Add determinate progress tracking

### DIFF
--- a/ffmpeg_stream_selector.py
+++ b/ffmpeg_stream_selector.py
@@ -275,12 +275,14 @@ class StreamSelectorApp(QWidget):
             return
 
         self.status_label.setText("Converting... please wait")
+        self.progress_bar.setRange(0, len(self.video_files))
+        self.progress_bar.setValue(0)
         self.progress_bar.show()
         self.convert_video_btn.setEnabled(False)
         self.update_streams_btn.setEnabled(False)
         QApplication.processEvents()
 
-        for input_file in self.video_files:
+        for idx, input_file in enumerate(self.video_files, start=1):
             try:
                 result = subprocess.run(
                     [
@@ -367,6 +369,9 @@ class StreamSelectorApp(QWidget):
                     message="FFmpeg failed during conversion",
                 )
 
+            self.progress_bar.setValue(idx)
+            QApplication.processEvents()
+
         self.ask_commit_updates()
         self.status_label.setText("Done")
         self.progress_bar.hide()
@@ -379,6 +384,8 @@ class StreamSelectorApp(QWidget):
             return
 
         self.status_label.setText("Updating streams... please wait")
+        self.progress_bar.setRange(0, len(self.video_files))
+        self.progress_bar.setValue(0)
         self.progress_bar.show()
         self.convert_video_btn.setEnabled(False)
         self.update_streams_btn.setEnabled(False)
@@ -395,7 +402,7 @@ class StreamSelectorApp(QWidget):
         subtitle_index = subtitle.split(" ")[1]
         audio_index = audio.split(" ")[1]
 
-        for input_file in self.video_files:
+        for idx, input_file in enumerate(self.video_files, start=1):
             converted_dir = os.path.join(os.path.dirname(input_file), "converted")
             os.makedirs(converted_dir, exist_ok=True)
             output_path = os.path.join(converted_dir, os.path.basename(input_file))
@@ -453,6 +460,9 @@ class StreamSelectorApp(QWidget):
                     input_file=input_file,
                     message="FFmpeg failed during stream update",
                 )
+
+            self.progress_bar.setValue(idx)
+            QApplication.processEvents()
 
         self.ask_commit_updates()
         self.status_label.setText("Done")

--- a/ffmpeg_stream_selector.py
+++ b/ffmpeg_stream_selector.py
@@ -65,11 +65,13 @@ class StreamSelectorApp(QWidget):
         self.update_streams_btn.setStyleSheet("background-color: #90ee90;")
         self.update_streams_btn.clicked.connect(self.update_streams)
         layout.addWidget(self.update_streams_btn, 4, 0, 1, 2)
+        self.update_streams_btn.setEnabled(False)
 
         self.convert_video_btn = QPushButton("Convert to HEVC")
         self.convert_video_btn.setStyleSheet("background-color: #add8e6;")
         self.convert_video_btn.clicked.connect(self.convert_to_hevc)
         layout.addWidget(self.convert_video_btn, 5, 0, 1, 2)
+        self.convert_video_btn.setEnabled(False)
 
         self.progress_bar = QProgressBar()
         self.progress_bar.setRange(0, 0)
@@ -172,12 +174,16 @@ class StreamSelectorApp(QWidget):
             self.log_status(
                 "error", message="No MKV or MP4 files found in selected folder."
             )
+            self.convert_video_btn.setEnabled(False)
+            self.update_streams_btn.setEnabled(False)
             return
 
         self.current_index = 0
         self.selected_file = self.video_files[self.current_index]
         self.current_file = self.selected_file
         self.populate_stream_dropdowns(self.selected_file)
+        self.convert_video_btn.setEnabled(True)
+        self.update_streams_btn.setEnabled(True)
 
     def run_ffprobe(self, filepath, stream_type):
         try:
@@ -303,6 +309,11 @@ class StreamSelectorApp(QWidget):
     def convert_to_hevc(self):
         if not getattr(self, "video_files", None):
             self.log_status("error", message="Please select a folder first.")
+            QMessageBox.warning(
+                self,
+                "No Folder Selected",
+                "Please select a folder first.",
+            )
             return
 
         self.status_label.setText("Converting... please wait")
@@ -420,6 +431,11 @@ class StreamSelectorApp(QWidget):
     def update_streams(self):
         if not getattr(self, "video_files", None):
             self.log_status("error", message="Please select a folder first.")
+            QMessageBox.warning(
+                self,
+                "No Folder Selected",
+                "Please select a folder first.",
+            )
             return
 
         self.status_label.setText("Updating streams... please wait")


### PR DESCRIPTION
## Summary
- show determinate progress during conversion and stream updates
- update progress bar value after each file

## Testing
- `python -m py_compile ffmpeg_stream_selector.py`

------
https://chatgpt.com/codex/tasks/task_e_687a170e83f08320a79ce80be1a7a38f