### PR TITLE
Enhance JSON logging with codec and size info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,19 @@ folder:
   already encoded in HEVC or AV1.
 * **Update Streams** – remuxes the chosen audio and subtitle streams while
   keeping the video stream as is.
+
+After processing, a `conversion_status.json` file is written to the same
+directory. Each entry in this log now includes the codec and file size before
+and after processing:
+
+```json
+{
+  "status": "converted",
+  "input": "original.mkv",
+  "output": "converted/original.mkv",
+  "before_codec": "h264",
+  "after_codec": "hevc",
+  "before_size": 12345678,
+  "after_size": 9876543
+}
+```

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ folder:
 * **Update Streams** – remuxes the chosen audio and subtitle streams while
   keeping the video stream as is.
 
-After processing, a `conversion_status.json` file is written to the same
-directory. Each entry in this log now includes the codec and file size before
-and after processing:
+After processing, a `conversion_status.json` file is saved to your
+`~/Documents` folder. Each entry in this log includes the codec and file size
+before and after processing:
 
 ```json
 {

--- a/ffmpeg_stream_selector.py
+++ b/ffmpeg_stream_selector.py
@@ -138,10 +138,10 @@ class StreamSelectorApp(QWidget):
         self.processed_dirs.clear()
 
     def write_status_log(self):
-        """Write collected status information to a JSON file."""
-        output_dir = DEFAULT_VIDEO_DIR
-        output_dir.mkdir(parents=True, exist_ok=True)
-        with open(output_dir / "conversion_status.json", "w", encoding="utf-8") as f:
+        """Write collected status information to a JSON file in ~/Documents."""
+        documents_dir = Path.home() / "Documents"
+        documents_dir.mkdir(parents=True, exist_ok=True)
+        with open(documents_dir / "conversion_status.json", "w", encoding="utf-8") as f:
             json.dump(self.status_log, f, indent=2)
 
     def ask_commit_updates(self):


### PR DESCRIPTION
## Summary
- record more details about each processed file, including codec and size before and after
- expose helper to read video codec
- document new JSON log fields in the README

## Testing
- `python -m py_compile ffmpeg_stream_selector.py`

------
https://chatgpt.com/codex/tasks/task_e_687a27a234dc8320ac5470c9da21ae8b