### PR TITLE
Automate influx push after HEVC conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ You can push the `conversion_status.json` log into InfluxDB for reporting with G
    ```bash
    export INFLUX_TOKEN=SC2OJktMgeOAQGjAxCx3NmNvq4_-CgEQoQiW7hST0TZiOt8q-zZA7MY-3X5VV3uJlB7DXbEnwCP7C95LhHAB1g==
    export INFLUX_URL=http://192.168.1.28:8086
-   export INFLUX_ORG=my-org  # replace with your organization
-   ```
-3. Run the uploader script:
-   ```bash
-   python upload_to_influxdb.py
-   ```
+ export INFLUX_ORG=my-org  # replace with your organization
+  ```
+3. Run the uploader script manually, or let the application call it
+   automatically after each HEVC conversion:
+  ```bash
+  python upload_to_influxdb.py
+  ```
 
 The script writes each entry to the `Video_Convert` bucket using the
 `video_conversion` measurement. Once uploaded, add InfluxDB as a data source in

--- a/ffmpeg_stream_selector.py
+++ b/ffmpeg_stream_selector.py
@@ -157,6 +157,12 @@ class StreamSelectorApp(QWidget):
         if reply == QMessageBox.Yes:
             self.commit_converted_files()
             self.write_status_log()
+            try:
+                import upload_to_influxdb
+
+                upload_to_influxdb.main()
+            except Exception as e:
+                print(f"Influx upload failed: {e}")
             QMessageBox.information(
                 self,
                 "Commit Complete",
@@ -600,3 +606,9 @@ if __name__ == "__main__":
     if getattr(window, "processed_dirs", None):
         window.commit_converted_files()
         window.write_status_log()
+        try:
+            import upload_to_influxdb
+
+            upload_to_influxdb.main()
+        except Exception as e:
+            print(f"Influx upload failed: {e}")


### PR DESCRIPTION
## Summary
- trigger InfluxDB upload after committing converted files
- run the upload when closing with pending files
- mention automatic upload in README

## Testing
- `python -m py_compile ffmpeg_stream_selector.py upload_to_influxdb.py`

------
https://chatgpt.com/codex/tasks/task_e_687a30badbdc8320b7e98ab337c3b057