### PR TITLE
Support uploading multiple logs to Influx

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ before and after processing:
 
 ## Upload results to InfluxDB
 
-You can push the `conversion_status.json` log into InfluxDB for reporting with Grafana.
+You can push the `conversion_status.json` log into InfluxDB for reporting with Grafana.  
+Recent updates also generate `convert.json` and `streams.json`. These files
+summarise HEVC conversions and stream selections respectively. The uploader
+now reads all three logs and writes them to InfluxDB using a measurement name
+matching the JSON filename.
 
 1. Install the InfluxDB Python client:
    ```bash
@@ -54,6 +58,7 @@ You can push the `conversion_status.json` log into InfluxDB for reporting with G
   python upload_to_influxdb.py
   ```
 
-The script writes each entry to the `Video_Convert` bucket using the
-`video_conversion` measurement. Once uploaded, add InfluxDB as a data source in
-Grafana and build dashboards from that measurement.
+Each log is written to the `Video_Convert` bucket with a measurement name
+matching the JSON filename (for example `convert` or `streams`). Once uploaded,
+add InfluxDB as a data source in Grafana and build dashboards from those
+measurements.

--- a/upload_to_influxdb.py
+++ b/upload_to_influxdb.py
@@ -8,7 +8,12 @@ INFLUX_BUCKET = "Video_Convert"
 INFLUX_ORG = os.getenv("INFLUX_ORG", "my-org")
 INFLUX_TOKEN = os.getenv("INFLUX_TOKEN")
 
-STATUS_PATH = Path.home() / "Documents" / "conversion_status.json"
+DOCUMENTS_DIR = Path.home() / "Documents"
+STATUS_FILES = [
+    "conversion_status.json",
+    "convert.json",
+    "streams.json",
+]
 
 
 def load_entries(path):
@@ -19,30 +24,36 @@ def load_entries(path):
         return json.load(f)
 
 
-def send_to_influxdb(entries):
-    if not INFLUX_TOKEN:
-        raise RuntimeError("INFLUX_TOKEN environment variable is not set")
-    with InfluxDBClient(url=INFLUX_URL, token=INFLUX_TOKEN, org=INFLUX_ORG) as client:
-        write_api = client.write_api(write_options=WriteOptions(batch_size=1, flush_interval=1000))
-        for entry in entries:
-            point = (
-                Point("video_conversion")
-                .tag("status", entry.get("status", ""))
-                .field("input", entry.get("input", ""))
-                .field("output", entry.get("output", ""))
-                .field("before_codec", entry.get("before_codec", ""))
-                .field("after_codec", entry.get("after_codec", ""))
-                .field("before_size", int(entry.get("before_size", 0)))
-                .field("after_size", int(entry.get("after_size", 0)))
-            )
-            write_api.write(bucket=INFLUX_BUCKET, record=point)
+def send_entries(entries, measurement, write_api):
+    for entry in entries:
+        point = Point(measurement)
+        for key, value in entry.items():
+            if isinstance(value, (int, float)):
+                point.field(key, value)
+            else:
+                point.tag(key, str(value))
+        write_api.write(bucket=INFLUX_BUCKET, record=point)
 
 
 def main():
-    entries = load_entries(STATUS_PATH)
-    if entries:
-        send_to_influxdb(entries)
-        print(f"Uploaded {len(entries)} records to {INFLUX_BUCKET}")
+    if not INFLUX_TOKEN:
+        raise RuntimeError("INFLUX_TOKEN environment variable is not set")
+
+    with InfluxDBClient(url=INFLUX_URL, token=INFLUX_TOKEN, org=INFLUX_ORG) as client:
+        write_api = client.write_api(
+            write_options=WriteOptions(batch_size=1, flush_interval=1000)
+        )
+
+        for fname in STATUS_FILES:
+            path = DOCUMENTS_DIR / fname
+            entries = load_entries(path)
+            if not entries:
+                continue
+            measurement = Path(fname).stem
+            send_entries(entries, measurement, write_api)
+            print(
+                f"Uploaded {len(entries)} records from {fname} to {INFLUX_BUCKET}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `upload_to_influxdb.py` so it uploads `convert.json` and `streams.json`
- set measurement names based on the filename
- document the new behaviour in `README`

## Testing
- `python -m py_compile ffmpeg_stream_selector.py upload_to_influxdb.py`

------
https://chatgpt.com/codex/tasks/task_e_687a8312b1088320975f966fa9ddfa99