### PR TITLE
Add scalable background image

### DIFF
--- a/ffmpeg_stream_selector.py
+++ b/ffmpeg_stream_selector.py
@@ -35,6 +35,14 @@ class StreamSelectorApp(QWidget):
         # Increase window size by one third to provide more room for widgets
         self.resize(600, 400)
 
+        # Add background image that scales with the window size
+        bg_path = Path(__file__).resolve().parent / "images" / "background.png"
+        if bg_path.exists():
+            # border-image allows scaling the image to the widget dimensions
+            self.setStyleSheet(
+                f"border-image: url('{bg_path.as_posix()}') 0 0 0 0 stretch stretch;"
+            )
+
         layout = QGridLayout()
         self.setLayout(layout)
         layout.setColumnStretch(0, 1)

--- a/ffmpeg_stream_selector.py
+++ b/ffmpeg_stream_selector.py
@@ -35,12 +35,14 @@ class StreamSelectorApp(QWidget):
         # Increase window size by one third to provide more room for widgets
         self.resize(600, 400)
 
+        self.setObjectName("mainWindow")
+
         # Add background image that scales with the window size
         bg_path = Path(__file__).resolve().parent / "images" / "background.png"
         if bg_path.exists():
-            # border-image allows scaling the image to the widget dimensions
+            # Apply style only to this widget so child widgets keep their own appearance
             self.setStyleSheet(
-                f"border-image: url('{bg_path.as_posix()}') 0 0 0 0 stretch stretch;"
+                f"#mainWindow {{border-image: url('{bg_path.as_posix()}') 0 0 0 0 stretch stretch;}}"
             )
 
         layout = QGridLayout()


### PR DESCRIPTION
## Summary
- add `background.png` as a scalable GUI background

## Testing
- `python -m py_compile ffmpeg_stream_selector.py`


------
https://chatgpt.com/codex/tasks/task_e_687b7d8431088320bf68fc5a37eff23d