### PR TITLE
Secure token input for Influx bucket check

### DIFF
--- a/Check-InfluxBucketEmpty.ps1
+++ b/Check-InfluxBucketEmpty.ps1
@@ -1,11 +1,11 @@
-﻿# Check-InfluxBucketEmpty.ps1
+# Check-InfluxBucketEmpty.ps1
 # Confirms if the InfluxDB bucket is empty after a wipe
 
 # Configuration
 $InfluxHost = "http://192.168.1.28:8086"
 $Org = "Waterfall"
 $Bucket = "Video_Convert"
-$Token = "SC2OJktMgeOAQGjAxCx3NmNvq4_-CgEQoQiW7hST0TZiOt8q-zZA7MY-3X5VV3uJlB7DXbEnwCP7C95LhHAB1g=="
+$Token = Read-Host "Enter your InfluxDB API token"
 
 Write-Host "`nChecking if bucket '$Bucket' contains any remaining data..."
 


### PR DESCRIPTION
## Summary
- prompt for the InfluxDB token instead of hardcoding it
- normalize line endings and ensure file ends with newline
- remove UTF-8 BOM from the script

## Testing
- `python -m py_compile upload_to_influxdb.py ffmpeg_stream_selector.py`


------
https://chatgpt.com/codex/tasks/task_e_687bf4ebb78c832092060214526dcc5b