### PR TITLE
Show ffmpeg progress with filename

### DIFF
--- a/ffmpeg_stream_selector.py
+++ b/ffmpeg_stream_selector.py
@@ -396,6 +396,7 @@ class StreamSelectorApp(QWidget):
         self.convert_log = []
 
         for idx, input_file in enumerate(self.video_files, start=1):
+            self.current_file = input_file
             duration = self.get_duration(input_file)
             before_size = os.path.getsize(input_file)
             try:
@@ -476,7 +477,7 @@ class StreamSelectorApp(QWidget):
                     fps, time_pos = self.parse_ffmpeg_progress(line)
                     if fps or time_pos:
                         self.status_label.setText(
-                            f"fps: {fps} time: {time_pos}"
+                            f"{os.path.basename(input_file)} - fps: {fps} time: {time_pos}"
                         )
                         if duration and time_pos:
                             secs = self.time_to_seconds(time_pos)
@@ -562,6 +563,7 @@ class StreamSelectorApp(QWidget):
         audio_index = audio.split(" ")[1]
 
         for idx, input_file in enumerate(self.video_files, start=1):
+            self.current_file = input_file
             duration = self.get_duration(input_file)
             before_codec = self.get_video_codec(input_file)
             before_size = os.path.getsize(input_file)
@@ -601,7 +603,7 @@ class StreamSelectorApp(QWidget):
                     fps, time_pos = self.parse_ffmpeg_progress(line)
                     if fps or time_pos:
                         self.status_label.setText(
-                            f"fps: {fps} time: {time_pos}"
+                            f"{os.path.basename(input_file)} - fps: {fps} time: {time_pos}"
                         )
                         if duration and time_pos:
                             secs = self.time_to_seconds(time_pos)


### PR DESCRIPTION
## Summary
- display the filename along with ffmpeg progress in `ffmpeg_stream_selector.py`
- keep track of `current_file` while processing each item

## Testing
- `python -m py_compile ffmpeg_stream_selector.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2dcf2df88320a2580841a797cd94