### PR TITLE
Preserve streams when converting to HEVC

### DIFF
--- a/theatre_gui.py
+++ b/theatre_gui.py
@@ -491,6 +491,8 @@ class TheatreApp(tk.Tk):
                 "-y",
                 "-i",
                 input_file,
+                "-map",
+                "0",
                 "-c:v",
                 "hevc_amf",
                 "-c:a",


### PR DESCRIPTION
## Summary
- Ensure Convert to HEVC command maps all streams and copies audio/subtitle tracks untouched

## Testing
- `python -m py_compile theatre_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3113e2ec48320968e17bf6f924298