### PR TITLE
Check for ffmpeg/ffprobe, handle missing tools gracefully, and update README with runtime deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,48 @@ The script expects `images/movie_theatre.png` to be present and requires a graph
 
 ## Requirements
 
-Only [Pillow](https://python-pillow.org/) is required. Install dependencies using:
+Python dependency:
+- [Pillow](https://python-pillow.org/)
+
+System/runtime dependencies (Linux):
+- `ffmpeg` (provides both `ffmpeg` and `ffprobe`)
+- `python3-tk` (Tkinter GUI runtime)
+
+Install Python dependencies using:
 
 ```bash
 pip install -r requirements.txt
 ```
+
+### Ubuntu/Debian note (PEP 668: externally-managed-environment)
+
+If you see `error: externally-managed-environment`, you are using the system
+Python `pip` instead of a project virtual environment `pip`. On Ubuntu/Debian,
+use the steps below to ensure the venv-local installer is used:
+
+```bash
+# one-time system packages
+sudo apt update
+sudo apt install -y python3-venv python3-full
+
+# from the project root
+python3 -m venv .venv
+source .venv/bin/activate
+
+# always prefer python -m pip to avoid pip-path confusion
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
+
+Quick verification:
+
+```bash
+which python
+which pip
+python -m pip --version
+```
+
+`which python` and `which pip` should both point inside `.venv/`.
 
 ## InfluxDB Configuration
 

--- a/theatre_gui.py
+++ b/theatre_gui.py
@@ -2,6 +2,7 @@ import os
 import json
 import subprocess
 import sys
+import shutil
 from pathlib import Path
 from datetime import datetime
 
@@ -144,8 +145,29 @@ class TheatreApp(tk.Tk):
         self.status_log = []
         self.convert_log = []
         self.streams_log = []
+        self._missing_tool_alert_shown = False
 
         self.protocol("WM_DELETE_WINDOW", self.quit_app)
+
+    def _handle_missing_tool(self, tool_name: str):
+        self.log_status(
+            "error",
+            message=f"Missing required tool: {tool_name}. Install ffmpeg to provide ffmpeg/ffprobe.",
+        )
+        if self._missing_tool_alert_shown:
+            return
+        self._missing_tool_alert_shown = True
+        messagebox.showerror(
+            "Missing dependency",
+            (
+                f"'{tool_name}' was not found.\n\n"
+                "Please install ffmpeg (it includes ffprobe) and restart the app.\n"
+                "Ubuntu/Debian: sudo apt install -y ffmpeg python3-tk"
+            ),
+        )
+
+    def _ffmpeg_tools_available(self):
+        return shutil.which("ffmpeg") and shutil.which("ffprobe")
 
     def _load_last_folder(self):
         if SETTINGS_FILE.exists():
@@ -298,6 +320,9 @@ class TheatreApp(tk.Tk):
                 creationflags=CREATE_NO_WINDOW,
             )
             return json.loads(result.stdout).get("streams", [])
+        except FileNotFoundError:
+            self._handle_missing_tool("ffprobe")
+            return []
         except subprocess.CalledProcessError as e:
             print(f"ffprobe failed for stream type '{stream_type}':", e)
             return []
@@ -335,6 +360,9 @@ class TheatreApp(tk.Tk):
                 creationflags=CREATE_NO_WINDOW,
             )
             return result.stdout.strip().lower()
+        except FileNotFoundError:
+            self._handle_missing_tool("ffprobe")
+            return None
         except Exception:
             return None
 
@@ -357,6 +385,9 @@ class TheatreApp(tk.Tk):
                 creationflags=CREATE_NO_WINDOW,
             )
             return float(result.stdout.strip())
+        except FileNotFoundError:
+            self._handle_missing_tool("ffprobe")
+            return None
         except Exception as e:
             print(f"ffprobe duration error for {filepath}:", e)
             return None
@@ -425,6 +456,10 @@ class TheatreApp(tk.Tk):
             self.subtitle_dropdown.set(subtitle_options[0])
 
     def convert_to_hevc(self):
+        if not self._ffmpeg_tools_available():
+            self._handle_missing_tool("ffmpeg/ffprobe")
+            return
+
         if not getattr(self, "video_files", None):
             self.log_status("error", message="Please select a folder first.")
             messagebox.showwarning("No Folder Selected", "Please select a folder first.")
@@ -536,6 +571,9 @@ class TheatreApp(tk.Tk):
                     )
                 else:
                     raise subprocess.CalledProcessError(ret, cmd)
+            except FileNotFoundError:
+                self._handle_missing_tool("ffmpeg")
+                break
             except subprocess.CalledProcessError as e:
                 print("FFmpeg error:", e)
                 self.log_status("error", input_file=input_file, message="FFmpeg failed during conversion")
@@ -551,6 +589,10 @@ class TheatreApp(tk.Tk):
         self.update_streams_btn.config(state="normal")
 
     def update_streams(self):
+        if not self._ffmpeg_tools_available():
+            self._handle_missing_tool("ffmpeg/ffprobe")
+            return
+
         if not getattr(self, "video_files", None):
             self.log_status("error", message="Please select a folder first.")
             messagebox.showwarning("No Folder Selected", "Please select a folder first.")
@@ -664,6 +706,9 @@ class TheatreApp(tk.Tk):
                     )
                 else:
                     raise subprocess.CalledProcessError(ret, cmd)
+            except FileNotFoundError:
+                self._handle_missing_tool("ffmpeg")
+                break
             except subprocess.CalledProcessError as e:
                 print("FFmpeg error:", e)
                 self.log_status("error", input_file=input_file, message="FFmpeg failed during stream update")


### PR DESCRIPTION
### Motivation
- Ensure the GUI fails gracefully and informs the user when external tools (`ffmpeg`/`ffprobe`) are missing.
- Improve developer/user setup instructions by documenting runtime system packages and virtualenv steps for Ubuntu/Debian.
- Prevent unhandled `FileNotFoundError` during probe/convert operations and avoid cascading errors when tools are unavailable.

### Description
- Added `shutil` import and helper methods `_ffmpeg_tools_available()` and `_handle_missing_tool()` to detect and report missing `ffmpeg`/`ffprobe` and show a single error dialog.
- Updated `run_ffprobe`, `get_video_codec`, and `get_duration` to catch `FileNotFoundError` and call the missing-tool handler, returning sensible defaults when tools are absent.
- Added pre-checks in `convert_to_hevc` and `update_streams` to early-exit with a user-visible error if `ffmpeg`/`ffprobe` are not found, and catch `FileNotFoundError` during long-running `ffmpeg` subprocess loops to stop processing gracefully.
- Extended `README.md` to list Python and system runtime dependencies (`ffmpeg`, `python3-tk`), provide `pip install -r requirements.txt` usage, and add Ubuntu/Debian virtual environment setup steps (PEP 668 note and `python3 -m venv .venv` flow).

### Testing
- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d01063ecd483209a26e9400053d74b)